### PR TITLE
Make CMake use venv Python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ install(TARGETS myactuator_rmd
 )
 
 if(PYTHON_BINDINGS)
-  find_package(Python REQUIRED COMPONENTS
+  find_package(Python3 REQUIRED COMPONENTS
     Development  
     Interpreter
   )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class CMakeBuild(build_ext):
 
         cmake_args = [
             f"-D CMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}{os.sep}",
-            f"-D PYTHON_EXECUTABLE={sys.executable}",
+            f"-D Python3_EXECUTABLE={sys.executable}",
             f"-D CMAKE_BUILD_TYPE={cfg}",
             f"-D PYTHON_BINDINGS=on"
         ]


### PR DESCRIPTION
This pull request makes **CMake** use the **venv Python** in a virtual environment. For more details see the pull request in the forked repository https://github.com/ggplijter/myactuator_rmd/pull/1 as well as the corresponding issue https://github.com/2b-t/myactuator_rmd/issues/16.